### PR TITLE
Add context where appropriate

### DIFF
--- a/updater_example_test.go
+++ b/updater_example_test.go
@@ -1,6 +1,7 @@
 package updater_test
 
 import (
+	"context"
 	"io"
 	"log"
 	"net/http"
@@ -12,33 +13,35 @@ import (
 var rootReader, bootReader, mbrReader io.Reader
 
 func Example() {
+	ctx := context.Background()
+
 	const baseURL = "http://gokrazy:example@gokrazy/"
-	target, err := updater.NewTarget(baseURL, http.DefaultClient)
+	target, err := updater.NewTarget(ctx, baseURL, http.DefaultClient)
 	if err != nil {
 		log.Fatalf("checking target partuuid support: %v", err)
 	}
 
 	// Start with the root file system because writing to the non-active
 	// partition cannot break the currently running system.
-	if err := target.StreamTo("root", rootReader); err != nil {
+	if err := target.StreamTo(ctx, "root", rootReader); err != nil {
 		log.Fatalf("updating root file system: %v", err)
 	}
 
-	if err := target.StreamTo("boot", bootReader); err != nil {
+	if err := target.StreamTo(ctx, "boot", bootReader); err != nil {
 		log.Fatalf("updating boot file system: %v", err)
 	}
 
 	// Only relevant when running on PCs (e.g. router7), the Raspberry Pi does
 	// not use an MBR.
-	if err := target.StreamTo("mbr", mbrReader); err != nil {
+	if err := target.StreamTo(ctx, "mbr", mbrReader); err != nil {
 		log.Fatalf("updating MBR: %v", err)
 	}
 
-	if err := target.Switch(); err != nil {
+	if err := target.Switch(ctx); err != nil {
 		log.Fatalf("switching to non-active partition: %v", err)
 	}
 
-	if err := target.Reboot(); err != nil {
+	if err := target.Reboot(ctx); err != nil {
 		log.Fatalf("reboot: %v", err)
 	}
 }


### PR DESCRIPTION
This is to allow cancelling the calls from the caller side.
e.g. in the Reboot() case, where once the caller process (normally a gokrazy managed process) receives the SIGTERM signal which Reboot() itself happens to trigger via its calling of the `killSupervisedServicesAndUmountPerm()` function, to avoid a blocking behaviour until SIGKILL kicks in.

Context for this change here: https://github.com/gokrazy/selfupdate/pull/4#discussion_r2113998031